### PR TITLE
New workshop registration for previous students

### DIFF
--- a/workshop/models.py
+++ b/workshop/models.py
@@ -23,7 +23,7 @@ class Workshop(models.Model):
 
 
 class WorkshopRegistration(models.Model):
-    workshop = models.ForeignKey(Workshop, blank=True, null=True)
+    workshop = models.ForeignKey(Workshop, null=True)
     name = models.CharField(max_length=200)
     email = models.EmailField()
     roll_number = models.CharField(max_length=100)

--- a/workshop/views.py
+++ b/workshop/views.py
@@ -120,13 +120,13 @@ class WorkshopRegisterFormView(CreateView):
         workshop = Workshop.objects.get(id=self.kwargs.get('workshop_id', None))
 
         try:
-            application = WorkshopRegistration.objects.filter(email=form.cleaned_data.get('email'))
+            application = WorkshopRegistration.objects.filter(workshop=workshop , email=form.cleaned_data.get('email'))
         except WorkshopRegistration.DoesNotExist:
             application = None
 
         if application.exists():
             form._errors[forms.forms.NON_FIELD_ERRORS] = ErrorList([
-                u'Your are already registered'
+                u'You are already registered'
             ])
             return self.form_invalid(form)
 


### PR DESCRIPTION
Previously, if a student had registered for a workshop and if he wants to register for a new workshop, it said You are already registered. This commit fixes that, and also a typo fixed as well