### PR TITLE
Updated WebTeam link on home page

### DIFF
--- a/promotion/templates/promotion/index.html
+++ b/promotion/templates/promotion/index.html
@@ -362,7 +362,7 @@
         </section>
 
         <!-- Copyright -->
-        <div class="copyright">Webteam, <a href="http://foss.amrita.ac.in/">FOSS@Amrita</a></div>
+        <div class="copyright"><a href="http://foss.amrita.ac.in/club/teams/3/">WebTeam</a>, <a href="http://foss.amrita.ac.in">FOSS@Amrita</a></div>
     </div>
 
 </div>


### PR DESCRIPTION
I had updated the link for WebTeam on Home page which is initially redirecting [foss home page](foss@amrita.ac.in) to [WebTeam page](http://foss.amrita.ac.in/club/teams/3/) 