### PR TITLE
fix: correct the case for e-mail field in the password reset page

### DIFF
--- a/registration/templates/registration/password_reset_form.html
+++ b/registration/templates/registration/password_reset_form.html
@@ -32,7 +32,7 @@
                                 <div class="form-group">
                                     <label for="name">Email</label>
                                     <input type="email" class="form-control" name="email" id="email"
-                                           placeholder="example@example.com">
+                                           placeholder="example@example.com" style="text-transform:lowercase">
                                     <small class="form-text text-muted">
                                         Email id associated with your account
                                     </small>


### PR DESCRIPTION
The e-mail input field earlier was displaying the e-mail in uppercase which ideally should have been in lowercase. This pull request resolves that minor issue. 

**Before making the change :**

![awesomescreenshot-2017-12-30t08-36-54-713z](https://user-images.githubusercontent.com/20839661/34453102-c2166f24-ed71-11e7-9594-5711473e4421.gif)

**After making the change :**

![awesomescreenshot-2017-12-30t09-15-36-814z](https://user-images.githubusercontent.com/20839661/34453133-cc47670a-ed71-11e7-8920-7ce2771676d9.gif)
