### PR TITLE
added Issue Template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,19 @@
+**Summary:** 
+
+Summarize your issue here, preferably in one sentence (what went wrong, what should have happened instead)
+
+**Steps to reproduce the issue:** 
+
+How can we reproduce the issue?
+
+**Expected behavior:** 
+
+What did you expect the website to do?
+
+**Observed behavior:** 
+
+What did you see instead? Describe your issue in detail here.
+
+**GIF/Screenshots:** 
+
+Attach GIF/Screeshots of the issue here


### PR DESCRIPTION
Currently our GitHub repository lacks an issue template, which results in creation of issues which are really difficult for a developer/contributor to understand. This pull request aims to fix that issue. 

**Note-** If the default branch of the repository were to be changed in the future, the issue template would have to be placed in that branch; else the template won't be visible.    