### PR TITLE
added pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+Please make sure that these boxes are checked before submitting your pull request - Thank you !
+
+- [] Run unit tests with ```python manage.py test``` to make sure you didn't break anything.
+
+- [] If you have multiple commits, please combine them into a single commit by squashing them.
+
+- [] Please attach GIF/Screenshot(s) showing the changes you have made.
+
+**Issue Reference :**  
+
+Please provide a reference to the related issue here, if present.
+E.g- #IssueNumber
+
+**GIF/Screenshots :**
+
+Attach GIF/Screeshots here


### PR DESCRIPTION
Currently our GitHub repository lacks a pull request template. This pull request aims to fix that issue. 

**Note-** If the default branch of the repository were to be changed in the future, the pull request template would have to be placed in that branch; else the template won't be visible.    